### PR TITLE
Update shell tests to work with gitops-update-pipeline changes

### DIFF
--- a/test/shell-pipeline-tests/common.sh
+++ b/test/shell-pipeline-tests/common.sh
@@ -100,6 +100,7 @@ function assertContains() {
   local -r STRING=$1
   local -r SUBSTRING=$2
 
+  [[ -z $SUBSTRING ]] && echo -e "Assertion failed!\n '$STRING' contains '$SUBSTRING' but it is empty, so the assertion would otherwise yield a false positive result" && return 1;
   [[ "$STRING" =~ $SUBSTRING ]] || { echo -e "Assertion failed!\n '$STRING' does not contain '$SUBSTRING'" && return 1; }
 }
 
@@ -115,8 +116,8 @@ assertGitHubPullRequest() {
 
   # Expected values
   PIPELINE_RUN_UID=$(oc get pipelinerun "$PIPELINE_RUN_NAME" -o jsonpath={.metadata.uid})
-  IMAGE_REGISTRY=$(oc get pipelinerun "$PIPELINE_RUN_NAME" -o jsonpath={.status.results[?\(@.name==\'target-registry-url\'\)].value})
-  NEW_DIGEST=$(oc get pipelinerun "$PIPELINE_RUN_NAME" -o jsonpath={.status.results[?\(@.name==\'image-sha\'\)].value})
+  IMAGE_REGISTRY=$(oc get pipelinerun "$PIPELINE_RUN_NAME" -o jsonpath={.spec.params[?\(@.name==\'image-registry-repo\'\)].value})
+  NEW_DIGEST=$(oc get pipelinerun "$PIPELINE_RUN_NAME" -o jsonpath={.spec.params[?\(@.name==\'image-digest\'\)].value})
   BASE_REF_NAME=$(oc get pipelinerun "$PIPELINE_RUN_NAME" -o jsonpath={.spec.params[?\(@.name==\'gitRepoBranchBase\'\)].value})
   GIT_SERVER=$(oc get pipelinerun "$PIPELINE_RUN_NAME" -o jsonpath={.spec.params[?\(@.name==\'gitServer\'\)].value})
   GIT_ORG_NAME=$(oc get pipelinerun "$PIPELINE_RUN_NAME" -o jsonpath={.spec.params[?\(@.name==\'gitOrgName\'\)].value})

--- a/test/shell-pipeline-tests/openvino-tensorflow-housing/pipelines-test-openvino-tensorflow-housing.sh
+++ b/test/shell-pipeline-tests/openvino-tensorflow-housing/pipelines-test-openvino-tensorflow-housing.sh
@@ -81,8 +81,11 @@ oc apply -k "$GITOPS_UPDATE_PIPELINE_DIR_PATH"/
 GITOPS_UPDATE_PIPELINERUN_PATH="$GITOPS_UPDATE_PIPELINE_DIR_PATH"/example-pipelineruns/gitops-update-pipelinerun-tensorflow-housing.yaml
 GITOPS_UPDATE_PIPELINERUN_OVERRIDDEN_PATH="$GITOPS_UPDATE_PIPELINE_DIR_PATH"/example-pipelineruns/gitops-update-pipelinerun-tensorflow-housing-overridden.yaml
 cp "$GITOPS_UPDATE_PIPELINERUN_PATH" "$GITOPS_UPDATE_PIPELINERUN_OVERRIDDEN_PATH"
+NEW_DIGEST=$(oc get pipelinerun "$PIPELINE_RUN_NAME" -o jsonpath={.status.results[?\(@.name==\'buildah-sha\'\)].value})
+
 sed -i "s|value: username|value: redhat-rhods-qe|" "$GITOPS_UPDATE_PIPELINERUN_OVERRIDDEN_PATH"
 sed -i "s|value: ai-edge-gitops|value: ai-edge-ci-test|" "$GITOPS_UPDATE_PIPELINERUN_OVERRIDDEN_PATH"
+sed -i "s|value: sha256.*|value: ${NEW_DIGEST}|" "$GITOPS_UPDATE_PIPELINERUN_OVERRIDDEN_PATH"
 
 ## oc create pipeline run
 oc create -f "$GITOPS_UPDATE_PIPELINERUN_OVERRIDDEN_PATH"


### PR DESCRIPTION
@grdryn 
Tests didn't fail because they got an empty string for `IMAGE_REGISTRY` and `NEW_DIGEST` as a value for the `$SUBSTRING`, so the test `[[ "$STRING" =~ $SUBSTRING ]] ` returned true.

I have added an additional check to make sure the substring is not empty. Now the substring we are trying to find must be non-empty, so the tests would fail without additional changes. Tests now manually lookup the built digest from the aiedge-e2e pipeline and set it as a parameter for the subsequent gitops-update-pipeline run.